### PR TITLE
Add pricing and order total calculation

### DIFF
--- a/templates/admin_orders.html
+++ b/templates/admin_orders.html
@@ -15,9 +15,9 @@
   <div class="col-md-3"><input type="date" name="date_to" class="form-control" value="{{ request.args.get('date_to','') }}" placeholder="по дату"></div>
   <div class="col-md-2"><button class="btn btn-secondary" type="submit">Фильтр</button></div>
 </form>
-<p>Всего товаров в выборке: {{ total_qty }}</p>
+<p>Всего товаров в выборке: {{ total_qty }} | Сумма: {{ '%.2f'|format(total_price) }}</p>
 <table class="table table-bordered">
-<tr><th>ID</th><th>Пользователь</th><th>Статус</th><th>Создан</th><th>Дата доставки</th><th>Товары</th><th>Обновить</th></tr>
+<tr><th>ID</th><th>Пользователь</th><th>Статус</th><th>Создан</th><th>Дата доставки</th><th>Товары</th><th>Сумма</th><th>Обновить</th></tr>
 {% for o in orders %}
 <tr>
 <td>{{ o.id }}</td>
@@ -32,6 +32,7 @@
   {% endfor %}
   </ul>
 </td>
+<td>{{ '%.2f'|format(sum(it.product.price * it.quantity for it in o.items)) }}</td>
 <td>
   <form method="post" class="d-flex">
     <input type="hidden" name="order_id" value="{{ o.id }}">

--- a/templates/admin_product_edit.html
+++ b/templates/admin_product_edit.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block title %}Редактировать товар{% endblock %}
+{% block content %}
+<h1 class="mb-3">Редактировать товар</h1>
+<form method="post" class="mb-4">
+  <div class="row g-2">
+    <div class="col-md-3"><input type="text" name="name" class="form-control" value="{{ product.name }}" required></div>
+    <div class="col-md-2"><input type="number" name="quantity" class="form-control" value="{{ product.quantity }}"></div>
+    <div class="col-md-2"><input type="number" step="0.01" name="price" class="form-control" value="{{ product.price }}"></div>
+    <div class="col-md-3"><input type="text" name="image_url" class="form-control" value="{{ product.image_url }}"></div>
+    <div class="col-md-4 mt-2"><input type="text" name="description" class="form-control" value="{{ product.description }}"></div>
+    <div class="col-md-1 form-check mt-2"><input class="form-check-input" type="checkbox" name="is_published" id="pub" {% if product.is_published %}checked{% endif %}><label class="form-check-label" for="pub">Публ.</label></div>
+    <div class="col-md-1 form-check mt-2"><input class="form-check-input" type="checkbox" name="is_limited" id="lim" {% if product.is_limited %}checked{% endif %}><label class="form-check-label" for="lim">Огр.</label></div>
+  </div>
+  <button type="submit" class="btn btn-primary mt-2">Сохранить</button>
+</form>
+<a href="{{ url_for('admin_products') }}">Назад к списку</a>
+{% endblock %}

--- a/templates/admin_products.html
+++ b/templates/admin_products.html
@@ -6,7 +6,8 @@
   <div class="row g-2">
     <div class="col-md-2"><input type="text" name="name" class="form-control" placeholder="Название" required></div>
     <div class="col-md-2"><input type="number" name="quantity" class="form-control" placeholder="Количество"></div>
-    <div class="col-md-3"><input type="text" name="image_url" class="form-control" placeholder="URL картинки"></div>
+    <div class="col-md-2"><input type="number" step="0.01" name="price" class="form-control" placeholder="Цена"></div>
+    <div class="col-md-2"><input type="text" name="image_url" class="form-control" placeholder="URL картинки"></div>
     <div class="col-md-3"><input type="text" name="description" class="form-control" placeholder="Описание"></div>
     <div class="col-md-1 form-check"><input class="form-check-input" type="checkbox" name="is_published" id="pub"><label class="form-check-label" for="pub">Публикация</label></div>
     <div class="col-md-1 form-check"><input class="form-check-input" type="checkbox" name="is_limited" id="lim" checked><label class="form-check-label" for="lim">Огр.</label></div>
@@ -14,13 +15,15 @@
   <button type="submit" class="btn btn-primary mt-2">Сохранить</button>
 </form>
 <table class="table table-bordered">
-<tr><th>Название</th><th>Кол-во</th><th>Публикуется</th><th>Ограничен</th></tr>
+<tr><th>Название</th><th>Кол-во</th><th>Цена</th><th>Публикуется</th><th>Ограничен</th><th></th></tr>
 {% for p in products %}
 <tr>
 <td>{{ p.name }}</td>
 <td>{% if p.is_limited %}{{ p.quantity }}{% else %}&infin;{% endif %}</td>
+<td>{{ '%.2f'|format(p.price) }}</td>
 <td>{{ 'Да' if p.is_published else 'Нет' }}</td>
 <td>{{ 'Да' if p.is_limited else 'Нет' }}</td>
+<td><a href="{{ url_for('admin_product_edit', pid=p.id) }}" class="btn btn-sm btn-secondary">Редактировать</a></td>
 </tr>
 {% endfor %}
 </table>

--- a/templates/cart.html
+++ b/templates/cart.html
@@ -4,15 +4,18 @@
 <h1 class="mb-3">Корзина</h1>
 {% if items %}
 <table class="table table-bordered">
-<tr><th>Товар</th><th>Количество</th><th></th></tr>
+<tr><th>Товар</th><th>Количество</th><th>Цена</th><th>Сумма</th><th></th></tr>
 {% for it in items %}
 <tr>
 <td>{{ it.product.name }}</td>
 <td>{{ it.qty }}</td>
+<td>{{ '%.2f'|format(it.product.price) }}</td>
+<td>{{ '%.2f'|format(it.product.price * it.qty) }}</td>
 <td><a href="{{ url_for('remove_from_cart', pid=it.product.id) }}" class="btn btn-sm btn-danger">Удалить</a></td>
 </tr>
 {% endfor %}
 </table>
+<p><strong>Итого: {{ '%.2f'|format(total) }}</strong></p>
 <a href="{{ url_for('checkout') }}" class="btn btn-success">Оформить заказ</a>
 {% else %}
 <p>Корзина пуста</p>

--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -4,14 +4,17 @@
 <h1 class="mb-3">Оформление заказа</h1>
 {% if items %}
 <table class="table table-bordered mb-3">
-<tr><th>Товар</th><th>Количество</th></tr>
+<tr><th>Товар</th><th>Количество</th><th>Цена</th><th>Сумма</th></tr>
 {% for it in items %}
 <tr>
 <td>{{ it.product.name }}</td>
 <td>{{ it.qty }}</td>
+<td>{{ '%.2f'|format(it.product.price) }}</td>
+<td>{{ '%.2f'|format(it.product.price * it.qty) }}</td>
 </tr>
 {% endfor %}
 </table>
+<p><strong>Итого: {{ '%.2f'|format(total) }}</strong></p>
 <form method="post" class="w-25">
   <div class="mb-3">
     <label class="form-label">Дата доставки</label>

--- a/templates/orders.html
+++ b/templates/orders.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h1 class="mb-3">Мои заказы</h1>
 <table class="table table-bordered">
-<tr><th>ID</th><th>Статус</th><th>Создан</th><th>Дата доставки</th><th>Товары</th></tr>
+<tr><th>ID</th><th>Статус</th><th>Создан</th><th>Дата доставки</th><th>Товары</th><th>Сумма</th></tr>
 {% for o in orders %}
 <tr>
 <td>{{ o.id }}</td>
@@ -17,6 +17,7 @@
   {% endfor %}
   </ul>
 </td>
+<td>{{ '%.2f'|format(order_totals[o.id]) }}</td>
 </tr>
 {% endfor %}
 </table>

--- a/templates/shop.html
+++ b/templates/shop.html
@@ -10,6 +10,7 @@
       <div class="card-body">
         <h5 class="card-title">{{ p.name }}</h5>
         <p class="card-text">{{ p.description }}</p>
+        <p class="card-text">Цена: {{ '%.2f'|format(p.price) }}</p>
         {% if p.is_limited %}
           <p class="text-muted">В наличии: {{ p.quantity }}</p>
         {% endif %}


### PR DESCRIPTION
## Summary
- add `price` field to products model
- allow editing products via separate page
- display prices in storefront and cart
- compute order totals for users and admin
- show total order price when filtering admin orders

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684094907f2c8329b869a097c3293ff9