### PR TITLE
Add order comments, date filters, and image uploads

### DIFF
--- a/templates/admin_orders.html
+++ b/templates/admin_orders.html
@@ -7,7 +7,7 @@
     <select name="status" class="form-select">
       <option value="">Все статусы</option>
       {% for s in statuses %}
-        <option value="{{ s }}" {% if request.args.get('status')==s %}selected{% endif %}>{{ s }}</option>
+        <option value="{{ s }}" {% if request.args.get('status')==s %}selected{% endif %}>{{ status_titles[s] }}</option>
       {% endfor %}
     </select>
   </div>
@@ -24,7 +24,7 @@
         <div>
           <strong>#{{ o.id }}</strong> - {{ o.user.username }}
         </div>
-        <span>{{ o.status }}</span>
+        <span>{{ status_titles[o.status] }}</span>
       </div>
       <div class="mt-2">
         <small>Создан: {{ o.created_at.strftime('%Y-%m-%d') }}</small><br>
@@ -32,6 +32,7 @@
         {% if o.delivery_interval %}<small>Будет доставлено: {{ o.delivery_interval }}</small><br>{% endif %}
         {% if o.receipt_filename %}<small><a href="{{ url_for('uploaded_file', filename=o.receipt_filename) }}" target="_blank">Чек</a></small><br>{% endif %}
       </div>
+      {% if o.comment %}<p>{{ o.comment }}</p>{% endif %}
       <ul class="my-2">
       {% for item in o.items %}
         <li>{{ item.product.name }} - {{ item.quantity }}</li>
@@ -43,7 +44,7 @@
         <div class="col-12 col-md-4">
           <select name="status" class="form-select">
           {% for s in statuses %}
-            <option value="{{ s }}" {% if s == o.status %}selected{% endif %}>{{ s }}</option>
+            <option value="{{ s }}" {% if s == o.status %}selected{% endif %}>{{ status_titles[s] }}</option>
           {% endfor %}
           </select>
         </div>

--- a/templates/admin_product_edit.html
+++ b/templates/admin_product_edit.html
@@ -2,12 +2,12 @@
 {% block title %}Редактировать товар{% endblock %}
 {% block content %}
 <h1 class="mb-3">Редактировать товар</h1>
-<form method="post" class="mb-4">
+<form method="post" enctype="multipart/form-data" class="mb-4">
   <div class="row g-2">
     <div class="col-md-3"><input type="text" name="name" class="form-control" value="{{ product.name }}" required></div>
     <div class="col-md-2"><input type="number" name="quantity" class="form-control" value="{{ product.quantity }}"></div>
     <div class="col-md-2"><input type="number" step="0.01" name="price" class="form-control" value="{{ product.price }}"></div>
-    <div class="col-md-3"><input type="text" name="image_url" class="form-control" value="{{ product.image_url }}"></div>
+    <div class="col-md-3"><input type="file" name="image" class="form-control"></div>
     <div class="col-md-4 mt-2"><input type="text" name="description" class="form-control" value="{{ product.description }}"></div>
     <div class="col-md-1 form-check mt-2"><input class="form-check-input" type="checkbox" name="is_published" id="pub" {% if product.is_published %}checked{% endif %}><label class="form-check-label" for="pub">Публ.</label></div>
     <div class="col-md-1 form-check mt-2"><input class="form-check-input" type="checkbox" name="is_limited" id="lim" {% if product.is_limited %}checked{% endif %}><label class="form-check-label" for="lim">Огр.</label></div>

--- a/templates/admin_products.html
+++ b/templates/admin_products.html
@@ -2,12 +2,12 @@
 {% block title %}Товары{% endblock %}
 {% block content %}
 <h1 class="mb-3">Товары</h1>
-<form method="post" class="mb-4">
+<form method="post" enctype="multipart/form-data" class="mb-4">
   <div class="row g-2">
     <div class="col-md-2"><input type="text" name="name" class="form-control" placeholder="Название" required></div>
     <div class="col-md-2"><input type="number" name="quantity" class="form-control" placeholder="Количество"></div>
     <div class="col-md-2"><input type="number" step="0.01" name="price" class="form-control" placeholder="Цена"></div>
-    <div class="col-md-2"><input type="text" name="image_url" class="form-control" placeholder="URL картинки"></div>
+    <div class="col-md-2"><input type="file" name="image" class="form-control"></div>
     <div class="col-md-3"><input type="text" name="description" class="form-control" placeholder="Описание"></div>
     <div class="col-md-1 form-check"><input class="form-check-input" type="checkbox" name="is_published" id="pub"><label class="form-check-label" for="pub">Публикация</label></div>
     <div class="col-md-1 form-check"><input class="form-check-input" type="checkbox" name="is_limited" id="lim" checked><label class="form-check-label" for="lim">Огр.</label></div>

--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -25,6 +25,10 @@
     <input type="datetime-local" name="desired_datetime" class="form-control" required>
   </div>
   <div class="mb-3">
+    <label class="form-label">Комментарий к заказу</label>
+    <textarea name="comment" class="form-control" rows="3"></textarea>
+  </div>
+  <div class="mb-3">
     <label class="form-label">Чек об оплате (опционально)</label>
     <input type="file" name="receipt" class="form-control">
   </div>

--- a/templates/orders.html
+++ b/templates/orders.html
@@ -2,19 +2,25 @@
 {% block title %}Мои заказы{% endblock %}
 {% block content %}
 <h1 class="mb-3">Мои заказы</h1>
+<form method="get" class="row g-2 mb-3">
+  <div class="col-md-4"><input type="date" name="date_from" class="form-control" value="{{ request.args.get('date_from','') }}" placeholder="с даты"></div>
+  <div class="col-md-4"><input type="date" name="date_to" class="form-control" value="{{ request.args.get('date_to','') }}" placeholder="по дату"></div>
+  <div class="col-md-2"><button class="btn btn-secondary" type="submit">Фильтр</button></div>
+</form>
 <div class="row row-cols-1 g-3">
 {% for o in orders %}
   <div class="col">
     <div class="card p-3">
       <div class="d-flex justify-content-between mb-2">
         <strong>#{{ o.id }}</strong>
-        <span>{{ o.status }}</span>
+        <span>{{ status_titles[o.status] }}</span>
       </div>
       <div class="mb-2">
         <small>Создан: {{ o.created_at.strftime('%Y-%m-%d') }}</small><br>
         <small>Желаемая доставка: {{ o.desired_delivery.strftime('%Y-%m-%d %H:%M') if o.desired_delivery else '' }}</small><br>
         {% if o.delivery_interval %}<small>Будет доставлено: {{ o.delivery_interval }}</small><br>{% endif %}
       </div>
+      {% if o.comment %}<p>{{ o.comment }}</p>{% endif %}
       <ul class="mb-2">
         {% for item in o.items %}
           <li>{{ item.product.name }} - {{ item.quantity }}</li>

--- a/templates/shop.html
+++ b/templates/shop.html
@@ -6,7 +6,11 @@
 {% for p in products %}
   <div class="col">
     <div class="card h-100">
-      {% if p.image_url %}<img src="{{ p.image_url }}" class="card-img-top" alt="{{ p.name }}">{% endif %}
+      {% if p.image_filename %}
+        <img src="{{ url_for('uploaded_file', filename='products/' ~ p.image_filename) }}" class="card-img-top" alt="{{ p.name }}">
+      {% elif p.image_url %}
+        <img src="{{ p.image_url }}" class="card-img-top" alt="{{ p.name }}">
+      {% endif %}
       <div class="card-body">
         <h5 class="card-title">{{ p.name }}</h5>
         <p class="card-text">{{ p.description }}</p>


### PR DESCRIPTION
## Summary
- enable localized status titles
- let admins upload product images
- allow comments on orders
- support filtering by creation date for user orders
- show images from uploads on the storefront

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68409ae4e28c83299be8997eb979c5c1