### PR TITLE
Integrate account management

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 Flask_SQLAlchemy
 Werkzeug
+Flask-Login

--- a/templates/admin_orders.html
+++ b/templates/admin_orders.html
@@ -59,5 +59,6 @@
   </div>
 {% endfor %}
 </div>
-<a href="{{ url_for('admin_products') }}">Товары</a>
+<a href="{{ url_for('admin_products') }}">Товары</a> |
+<a href="{{ url_for('admin_users') }}">Пользователи</a>
 {% endblock %}

--- a/templates/admin_product_edit.html
+++ b/templates/admin_product_edit.html
@@ -14,5 +14,6 @@
   </div>
   <button type="submit" class="btn btn-primary mt-2">Сохранить</button>
 </form>
-<a href="{{ url_for('admin_products') }}">Назад к списку</a>
+<a href="{{ url_for('admin_products') }}">Назад к списку</a> |
+<a href="{{ url_for('admin_users') }}">Пользователи</a>
 {% endblock %}

--- a/templates/admin_products.html
+++ b/templates/admin_products.html
@@ -27,5 +27,6 @@
 </tr>
 {% endfor %}
 </table>
-<a href="{{ url_for('admin_orders') }}">Заказы</a>
+<a href="{{ url_for('admin_orders') }}">Заказы</a> |
+<a href="{{ url_for('admin_users') }}">Пользователи</a>
 {% endblock %}

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+{% block title %}Пользователи{% endblock %}
+{% block content %}
+<h1 class="mb-3">Пользователи</h1>
+<table class="table table-bordered">
+<tr><th>Имя</th><th>Телефон</th><th>Заблокирован</th><th>Действие</th></tr>
+{% for u in users %}
+<tr>
+<td>{{ u.username }}</td>
+<td>{{ u.phone }}</td>
+<td>{{ 'Да' if u.is_blocked else 'Нет' }}</td>
+<td>
+  <form method="post" class="d-inline">
+    <input type="hidden" name="user_id" value="{{ u.id }}">
+    <input type="hidden" name="block" value="{{ '0' if u.is_blocked else '1' }}">
+    <button type="submit" class="btn btn-sm {{ 'btn-success' if u.is_blocked else 'btn-danger' }}">
+      {{ 'Разблокировать' if u.is_blocked else 'Заблокировать' }}
+    </button>
+  </form>
+</td>
+</tr>
+{% endfor %}
+</table>
+<a href="{{ url_for('admin_products') }}">Товары</a>
+{% endblock %}
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,7 +12,7 @@
     <a class="navbar-brand" href="{{ url_for('index') }}">Магазин</a>
     <div class="collapse navbar-collapse">
       <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-        {% if current_user %}
+        {% if current_user.is_authenticated %}
         <li class="nav-item"><a class="nav-link" href="{{ url_for('cart_view') }}">Корзина</a></li>
         <li class="nav-item"><a class="nav-link" href="{{ url_for('my_orders') }}">Мои заказы</a></li>
         {% if current_user.is_admin %}


### PR DESCRIPTION
## Summary
- add Flask-Login to handle authentication
- enforce unique Russian phone numbers and add account blocking
- create admin user management page
- show user management links in admin templates

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`
- `python app.py` *(fails: server stops after start)*

------
https://chatgpt.com/codex/tasks/task_e_6840a20947c083299a0935db5d24032f